### PR TITLE
Introduce `lib/cashstar-ruby.rb` for Bundler

### DIFF
--- a/lib/cashstar-ruby.rb
+++ b/lib/cashstar-ruby.rb
@@ -1,0 +1,1 @@
+require "cashstar"


### PR DESCRIPTION
By default, Bundler will attempt to `require` the gem's name.

In this gem's case, the `caststar-ruby` file did not exist. As a
workaround, users were required to:

```rb
gem "cashstar-ruby", require: "cashstar"
```

This commit adds the `lib/cashstar-ruby.rb` file, so that Bundler will
implicitly require the `lib/cashstar.rb` file.